### PR TITLE
Fix code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/dist/jquery.inputmask.js
+++ b/dist/jquery.inputmask.js
@@ -2078,7 +2078,7 @@
                             if (!0 === t.keepStatic) {
                                 var a = e.match(new RegExp("(?<p1>.)\\[(?<p2>[^\\]]*)\\]", "g"));
                                 a && a.forEach((function(t, i) {
-                                    var a = t.split("["), n = a[0], r = a[1].replace("]", "");
+                                    var a = t.split("["), n = a[0], r = a[1].replace(/\]/g, "");
                                     e = e.replace(new RegExp("".concat((0, o.default)(n), "\\[").concat((0, o.default)(r), "\\]")), n.charAt(0) === r.charAt(0) ? "(".concat(n, "|").concat(n).concat(r, ")") : "".concat(n, "[").concat(r, "]"));
                                 }));
                             }


### PR DESCRIPTION
Fixes [https://github.com/RenatoPasquini/Inputmask/security/code-scanning/6](https://github.com/RenatoPasquini/Inputmask/security/code-scanning/6)

To fix the problem, we need to ensure that all occurrences of the substring `"]"` are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace the string literal `"]"` with the regular expression `/\]/g`.

This change should be made in the file `dist/jquery.inputmask.js` on line 2081. No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
