### PR TITLE
Fix code scanning alert no. 10: Incomplete string escaping or encoding

### DIFF
--- a/dist/jquery.inputmask.js
+++ b/dist/jquery.inputmask.js
@@ -2688,7 +2688,7 @@
                                         throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
                                     }();
                                 }(t.split("["), 2), r = i[0], o = i[1];
-                                o = o.replace("]", ""), e = e.replace(new RegExp("".concat((0, a.escapeRegex)(r), "\\[").concat((0, 
+                                o = o.replace(/\]/g, ""), e = e.replace(new RegExp("".concat((0, a.escapeRegex)(r), "\\[").concat((0, 
                                 a.escapeRegex)(o), "\\]")), r.charAt(0) === o.charAt(0) ? "(".concat(r, "|").concat(r).concat(o, ")") : "".concat(r, "[").concat(o, "]"));
                             }));
                         }


### PR DESCRIPTION
Fixes [https://github.com/RenatoPasquini/Inputmask/security/code-scanning/10](https://github.com/RenatoPasquini/Inputmask/security/code-scanning/10)

To fix the problem, we need to ensure that all occurrences of the substring `"]"` are replaced in the string `o`. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of the substring is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
