### PR TITLE
Fix code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/lib/mask-lexer.js
+++ b/lib/mask-lexer.js
@@ -38,7 +38,7 @@ function generateMaskSet(opts, nocache) {
       maskMatches &&
         maskMatches.forEach((m, i) => {
           let [p1, p2] = m.split("[");
-          p2 = p2.replace("]", "");
+          p2 = p2.replace(/\]/g, "");
           mask = mask.replace(
             new RegExp(`${escapeRegex(p1)}\\[${escapeRegex(p2)}\\]`),
             p1.charAt(0) === p2.charAt(0)


### PR DESCRIPTION
Fixes [https://github.com/RenatoPasquini/Inputmask/security/code-scanning/7](https://github.com/RenatoPasquini/Inputmask/security/code-scanning/7)

To fix the problem, we need to ensure that all occurrences of the `]` character in the string `p2` are replaced. This can be achieved by using a regular expression with the global flag in the `replace` method. This change will ensure that every instance of the character is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
